### PR TITLE
use date-fns lib to fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3516,6 +3516,16 @@
         }
       }
     },
+    "date-fns": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
+      "integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA=="
+    },
+    "date-fns-tz": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.0.9.tgz",
+      "integrity": "sha512-5VOe9FBMwhb3LjGttJhrxdgf6WrVwzu9HEU1H4KgJYAclt0UABmQhE/5jUaDsH7qktihxd22xF8zl6BChAYTAw=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@appbaseio/reactivesearch": "^3.1.1",
     "apexcharts": "^3.10.1",
     "bodybuilder": "^2.2.18",
+    "date-fns": "^2.9.0",
+    "date-fns-tz": "^1.0.9",
     "dotenv": "^8.2.0",
     "elasticsearch": "^16.5.0",
     "express": "^4.17.1",

--- a/src/pages/search/search.component.js
+++ b/src/pages/search/search.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { func, shape, string } from 'prop-types';
 import { parseQuery } from 'utils/query';
 import { twoDaysFromNow } from 'utils/date';
+import { zonedTimeToUtc } from 'date-fns-tz';
 import Button from 'components/button';
 import Tips from 'components/pages/tips';
 import Tweet from 'components/tweet';
@@ -107,6 +108,9 @@ export default class Search extends React.Component {
               defaultValue={{
                 start: new Date('2009-05-01'),
                 end: twoDaysFromNow(),
+              }}
+              dayPickerInputProps={{
+                parseDate: dateString => dateString ? zonedTimeToUtc(dateString, 'America/New_York') : dateString,
               }}
               URLParams={true}
             />


### PR DESCRIPTION
## Issue
The date range selector is sending dates in local time (PST for me), but the dates are stored in ES in UTC time.

## Solution
Pass props to the internals of react-day-picker, parsing the intention behind the date as EST (since we're displaying all tweets in EST) and re-formatting to UTC.

This generally seems to work. Leverages the `date-fns` lib, which doesn't really add much to the bundle size since imports are all functions (unlike OOP moment which includes a 200K bundle).