### PR TITLE
5 30 additions

### DIFF
--- a/src/app/app.component.js
+++ b/src/app/app.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { ReactiveBase } from '@appbaseio/reactivesearch';
+import BadHiresPage from 'components/pages/bad-hires';
 import FaqPage from 'components/pages/faq';
 import MainPage from 'components/pages/main';
 import SearchPage from 'components/pages/search';
@@ -15,6 +16,7 @@ export default class App extends React.Component {
           <BrowserRouter>
             <Navbar />
             <Switch>
+              <Route path="/bad-hires" component={BadHiresPage} />
               <Route path="/faq" component={FaqPage} />
               <Route path="/search" component={SearchPage} />
               <Route component={MainPage} />

--- a/src/external-link/external-link.component.js
+++ b/src/external-link/external-link.component.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { node, string } from 'prop-types';
 import { tweetLink } from 'utils/links';
 
-// for an external link to a trump tweet, just pass an id prop
+// for an external link to a trump tweet, just pass an tweetId prop
 
 export default class ExternalLink extends React.Component {
   static propTypes = {
     children: node.isRequired,
     className: string,
     href: string,
-    id: string,
+    tweetId: string,
     title: string,
   }
 
@@ -19,7 +19,7 @@ export default class ExternalLink extends React.Component {
   }
 
   get href () {
-    return this.props.id ? tweetLink(this.props.id) : this.props.href;
+    return this.props.tweetId ? tweetLink(this.props.tweetId) : this.props.href;
   }
 
   render () {

--- a/src/external-link/external-link.test.js
+++ b/src/external-link/external-link.test.js
@@ -22,7 +22,7 @@ describe('ExternalLink', () => {
 
   it('renders a url to a trump tweet if passed an id prop', () => {
     const wrapper = shallow(
-      <ExternalLink className="link" id="1">Some trump shit</ExternalLink>
+      <ExternalLink className="link" tweetId="1">Some trump shit</ExternalLink>
     );
     const url = wrapper.find('a').props().href;
     expect(url).toEqual(tweetLink(1));

--- a/src/latest-tweets/latest-tweets.component.js
+++ b/src/latest-tweets/latest-tweets.component.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import Button from 'components/button';
 import LatestTweet from './latest-tweet';
 import List from 'components/lists/list';
+import TextSwitch from 'components/text-switch';
 import Pagination from './pagination';
 import styles from './latest-tweets.style.scss';
 
@@ -37,7 +38,7 @@ export default class LatestTweets extends React.Component {
         button={this.buttonChangeTweetStyle}
         buttonTwo={this.buttonSearchPage}
         className={styles.latestTweets}
-        header="Latest tweets"
+        header={<TextSwitch web="Latest tweets" mobile="Latest" />}
       >
         <ReactiveList
           componentId="results"

--- a/src/lists/dog/dog.component.js
+++ b/src/lists/dog/dog.component.js
@@ -6,6 +6,12 @@ export default class Dog extends React.Component {
   render () {
     return (
       <List header="Dogs">
+        <TweetLink id="1256702883199881216">
+          Nicole Wallace <span>"thrown off The View like a dog"</span>
+        </TweetLink>
+        <TweetLink id="1255710938075889664">
+          Brian Williams <span>"thrown off Network News like a dog"</span>
+        </TweetLink>
         <TweetLink id="1159318329506574336">
           Tim O'Brien (biographer) <span>"fired like a dog from other jobs"</span>
         </TweetLink>

--- a/src/lists/dog/dog.component.js
+++ b/src/lists/dog/dog.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import findTweet from 'utils/data';
 import TweetLink from 'components/tweet-link';
 import List from '../list';
 
@@ -6,58 +7,58 @@ export default class Dog extends React.Component {
   render () {
     return (
       <List header="Dogs">
-        <TweetLink id="1256702883199881216">
+        <TweetLink tweetData={findTweet('1256702883199881216')}>
           Nicole Wallace <span>"thrown off The View like a dog"</span>
         </TweetLink>
-        <TweetLink id="1255710938075889664">
+        <TweetLink tweetData={findTweet('1255710938075889664')}>
           Brian Williams <span>"thrown off Network News like a dog"</span>
         </TweetLink>
-        <TweetLink id="1159318329506574336">
+        <TweetLink tweetData={findTweet('1159318329506574336')}>
           Tim O'Brien (biographer) <span>"fired like a dog from other jobs"</span>
         </TweetLink>
-        <TweetLink id="1080124615920373760">
+        <TweetLink tweetData={findTweet('1080124615920373760')}>
           General McChrystal <span>"fired like a dog by Obama"</span>
         </TweetLink>
-        <TweetLink id="949498795074736129">
+        <TweetLink tweetData={findTweet('949498795074736129')}>
           Steve Bannon <span>"dumped like a dog by almost everyone"</span>
         </TweetLink>
-        <TweetLink id="741590381503086592">
+        <TweetLink tweetData={findTweet('741590381503086592')}>
           Mitt Romney <span>"choked like a dog."</span>
         </TweetLink>
-        <TweetLink id="715013260462960642">
+        <TweetLink tweetData={findTweet('715013260462960642')}>
           David Gregory (Meet the Press) <span>"fired like a dog!"</span>
         </TweetLink>
-        <TweetLink id="710905631008546816">
+        <TweetLink tweetData={findTweet('710905631008546816')}>
           Erik Erickson (Red State) <span>"fired like a dog"</span>
         </TweetLink>
-        <TweetLink id="702149896325890048">
+        <TweetLink tweetData={findTweet('702149896325890048')}>
           Ted Cruz <span>"lies like a dog-over and over"</span>
         </TweetLink>
-        <TweetLink id="702141081027104769">
+        <TweetLink tweetData={findTweet('702141081027104769')}>
           Ted Cruz's Communication Director <span>"fired like a dog!"</span>
         </TweetLink>
-        <TweetLink id="690708660377513984">
+        <TweetLink tweetData={findTweet('690708660377513984')}>
           Brent Bozell (National Review) <span>"begging for money like a dog"</span>
         </TweetLink>
-        <TweetLink id="686327439870574592">
+        <TweetLink tweetData={findTweet('686327439870574592')}>
           Union Leader (newspaper) <span>"kicked out of the ABC News debate like a dog"</span>
         </TweetLink>
-        <TweetLink id="677339850752806912">
+        <TweetLink tweetData={findTweet('677339850752806912')}>
           Glenn Beck <span>"got fired like a dog"</span>
         </TweetLink>
-        <TweetLink id="620391296251916288">
+        <TweetLink tweetData={findTweet('620391296251916288')}>
           Chuck Todd <span>"will be fired like a dog"</span>
         </TweetLink>
-        <TweetLink id="589251220000403456">
+        <TweetLink tweetData={findTweet('589251220000403456')}>
           George Will <span>"thrown off ABC like a dog"</span>
         </TweetLink>
-        <TweetLink id="291568395621634049">
+        <TweetLink tweetData={findTweet('291568395621634049')}>
           Bill Maher <span>"fired like a dog...from ABC"</span>
         </TweetLink>
-        <TweetLink id="258640349872926720">
+        <TweetLink tweetData={findTweet('258640349872926720')}>
           Kristen Stewart <span>"cheated on him like a dog"</span> (Robert Pattinson)
         </TweetLink>
-        <TweetLink id="207864933373849601">
+        <TweetLink tweetData={findTweet('207864933373849601')}>
           Reverend Wright <span>"dumped like a dog by @BarackObama"</span>
         </TweetLink>
       </List>

--- a/src/lists/list/list.component.js
+++ b/src/lists/list/list.component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { node, string } from 'prop-types';
+import { node, oneOfType, string } from 'prop-types';
 import Icon from 'components/icon';
 import styles from './list.style.scss';
 
@@ -9,7 +9,7 @@ export default class List extends React.Component {
     buttonTwo: node,
     children: node.isRequired,
     className: string,
-    header: string.isRequired,
+    header: oneOfType([string, node]).isRequired,
   }
 
   static defaultProps = {

--- a/src/lists/staff/staff.component.js
+++ b/src/lists/staff/staff.component.js
@@ -3,53 +3,167 @@ import TweetLink from 'components/tweet-link';
 import List from '../list';
 import styles from './staff.style.scss';
 
+/*
+Gary Cohn
+*/
+
+/* eslint-disable */
+
+const StaffPerson = ({ header, insults, praiseId, time }) => (
+  <div>
+    <h3>{ header }</h3>
+    <div className={styles.wrapper}>
+      <div className={styles.left}>
+        <TweetLink id={praiseId} showEmbedded={true} />
+      </div>
+      <div className={styles.right}>
+        <h5>{time} months later, he begins to tweet...</h5>
+        { insults }
+      </div>
+    </div>
+  </div>
+);
+
 export default class Staff extends React.Component {
   render () {
     return (
       <List className={styles.staff} header="Bad hires">
-        {/* <p>On Twitter, the President of the United States publicly disparaged his own Secretary of State, Chief of Staff, Attorney General, National Security Advisor, Fed Chairman, Chief Strategist, Communications Director, and White House Counsel (all of whom he hired).</p> */}
-        <div>
-          <h3>Rex Tillerson (Secretary of State I)</h3>
-          <TweetLink className={styles.praise} id="808638507161882624" text="I have chosen one of the truly great business leaders of the world, Rex Tillerson, Chairman and CEO of ExxonMobil, to be Secretary of State. "/>
-          <TweetLink id="1131537528736100352" text="Rex Tillerson, a man who is dumb as a rock and totally ill prepared and ill equipped to be Secretary of State..."/>
-          <TweetLink id="1071132880368132096" text="Rex Tillerson, didn’t have the mental capacity needed. He was dumb as a rock and I couldn’t get rid of him fast enough. He was lazy as hell."/>
-        </div>
-        <div>
-          <h3>John Kelly (Chief of Staff II)</h3>
-          <TweetLink className={styles.praise} id="891038014314598400" text="I am pleased to inform you that I have just named General/Secretary John F Kelly as White House Chief of Staff. He is a Great American..."/>
-          <TweetLink id="1227986935240691712" text="When I terminated John Kelly, which I couldn’t do fast enough, he knew full well that he was way over his head. Being Chief of Staff just wasn’t for him. He came in with a bang, went out with a whimper, but like so many X’s, he misses the action & just can’t keep his mouth shut"/>
-        </div>
-        <div>
-          <h3>Jeff Sessions (Attorney General I)</h3>
-          <TweetLink className={styles.praise} id="829496507841789952" text="Congratulations to our new Attorney General, @SenatorSessions!"/>
-          <TweetLink id="889790429398528000" text="Attorney General Jeff Sessions has taken a VERY weak position on Hillary Clinton crimes"/>
-          <TweetLink id="890207082926022656" text="Why didn't A.G. Sessions replace Acting FBI Director Andrew McCabe"/>
-          <TweetLink id="968856971075051521" text="Why is A.G. Jeff Sessions asking the Inspector General to investigate potentially massive FISA abuse...DISGRACEFUL!"/>
-          <TweetLink id="1002027245131661312" text="The recusal of Jeff Sessions was an unforced betrayal of the President of the United States"/>
-          <TweetLink id="1003962584352030720" text="I would have quickly picked someone else. So much time and money wasted, so many lives ruined"/>
-          <TweetLink id="1030632303507243008" text="BLANK Jeff Sessions"/>
-          <TweetLink id="1104122208316612608" text="Sessions didn’t have a clue!"/>
-          <TweetLink id="1033332301579661312" text="he doesn’t understand what is happening underneath his command position"/>
-          <TweetLink id="1074403110523678720" text="Jeff Sessions should be ashamed of himself"/>
-        </div>
-        <div>
-          <h3>Jerome Powell (Fed Chairman I)</h3>
-          <TweetLink className={styles.praise} id="926216279287042048" text="Today, it was my pleasure and great honor to announce my nomination of Jerome Powell to be the next Chairman of the @FederalReserve."/>
-          <TweetLink id="1164914610836783104" text="who is our bigger enemy, Jay Powell or Chairman Xi?"/>
-          <TweetLink id="1156666164732473345" text="As usual, Powell let us down"/>
-          <TweetLink id="1161687635426983937" text="Jay Powell made TWO enormous mistakes"/>
-          <TweetLink id="1161719409804808193" text="clueless Jay Powell"/>
-          <TweetLink id="1163472272612626433" text="horrendous lack of vision by Jay Powell"/>
-          <TweetLink id="1164158321265451008" text="He’s like a golfer who can’t putt, has no touch...So far he has called it wrong, and only let us down"/>
-          <TweetLink id="1171735692428419072" text="the naivete of Jay Powell"/>
-          <TweetLink id="1173564172635914247" text="Jay Powell & the Fed don’t have a clue."/>
-          <TweetLink id="1174388901806362624" text="Jay Powell and the Federal Reserve Fail Again. No “guts,” no sense, no vision! A terrible communicator!"/>
-        </div>
-        <div>
-          <h3>Steve Bannon (Chief Strategist)</h3>
-          <TweetLink className={styles.praise} id="898870621584596993" text="I want to thank Steve Bannon for his service. He came to the campaign during my run against Crooked Hillary Clinton - it was great! Thanks S"/>
-          <TweetLink id="949498795074736129" text="Sloppy Steve Bannon, who cried when he got fired and begged for his job. Now Sloppy Steve has been dumped like a dog by almost everyone. Too bad!"/>
-        </div>
+        <p>On Twitter, the President of the United States publicly disparaged his own Secretary of State, Chief of Staff, Attorney General, National Security Advisor, Fed Chairman, Chief Strategist, Communications Director, and White House Counsel (all of whom he hired).</p>
+        <StaffPerson
+          header="Rex Tillerson (Secretary of State I)"
+          praiseId="808638507161882624"
+          time="24"
+          insults={[
+            <>
+              <TweetLink id="1071132880368132096">
+                Rex Tillerson was <span>"dumb as a rock"</span>
+              </TweetLink>
+              <TweetLink id="1131537528736100352">
+                Rex Tillerson was <span>"totally ill prepared and ill equipped to be Secretary of State"</span>
+              </TweetLink>
+              <TweetLink id="1071132880368132096">
+                Rex Tillerson <span>"didn’t have the mental capacity needed"</span>
+              </TweetLink>
+              <TweetLink id="1071132880368132096">
+                Rex Tillerson was <span>"lazy as hell"</span>
+              </TweetLink>
+              <TweetLink id="1131537528736100352">
+                Rex Tillerson is <span>"a man who is dumb as a rock"</span>
+              </TweetLink>
+              <TweetLink id="1071132880368132096">
+                Rex Tillerson: <span>"I couldn’t get rid of him fast enough"</span>
+              </TweetLink>
+            </>
+          ]}
+        />
+        <StaffPerson
+          header="John Kelly (Chief of Staff II)"
+          praiseId="891038014314598400"
+          time="30"
+          insults={[
+            <>
+              <TweetLink id="1227986935240691712">
+                John Kelly was <span>"way over his head"</span>
+              </TweetLink>
+              <TweetLink id="1227986935240691712">
+                John Kelly <span>"went out with a whimper"</span>
+              </TweetLink>
+              <TweetLink id="1227986935240691712">
+                John Kelly: <span>"being Chief of Staff just wasn’t for him"</span>
+              </TweetLink>
+              <TweetLink id="1227986935240691712">
+                John Kelly: <span>"I terminated John Kelly"</span>
+              </TweetLink>
+              <TweetLink id="1227986935240691712">
+                John Kelly <span>"just can’t keep his mouth shut"</span>
+              </TweetLink>
+            </>
+          ]}
+        />
+        <StaffPerson
+          header="Jeff Sessions (Attorney General I)"
+          praiseId="829496507841789952"
+          time="6"
+          insults={[
+            <>
+              <TweetLink id="1033332301579661312">
+                Jess Sessions <span>"doesn’t understand what is happening underneath his command"</span>
+              </TweetLink>
+              <TweetLink id="889790429398528000">
+                Jess Sessions has <span>"taken a VERY weak position on Hillary Clinton crimes"</span>
+              </TweetLink>
+              <TweetLink id="1002027245131661312">
+                Jess Sessions caused <span>"an unforced betrayal of the President of the United States"</span>
+              </TweetLink>
+              <TweetLink id="1030632303507243008">
+                Jess Sessions is <span>"BLANK"</span>
+              </TweetLink>
+              <TweetLink id="968856971075051521">
+                Jess Sessions is <span>"DISGRACEFUL!"</span>
+              </TweetLink>
+              <TweetLink id="1104122208316612608">
+                Jess Sessions <span>"didn’t have a clue!"</span>
+              </TweetLink>
+              <TweetLink id="1074403110523678720">
+                Jess Sessions <span>"should be ashamed of himself"</span>
+              </TweetLink>
+              <TweetLink id="1263970567838932993">
+                Alabama: <span>"do not trust Jeff Sessions"</span>
+              </TweetLink>
+            </>
+          ]}
+        />
+        <StaffPerson
+          header="Jay Powell (Fed Chairman I)"
+          praiseId="926216279287042048"
+          time="16"
+          insults={[
+            <>
+              <TweetLink id="1163472272612626433">
+                Jay Powell has <span>"horrendous lack of vision"</span>
+              </TweetLink>
+              <TweetLink id="1161687635426983937">
+                Jay Powell <span>"made TWO enormous mistakes"</span>
+              </TweetLink>
+              <TweetLink id="1173564172635914247">
+                Jay Powell doesn't <span>"have a clue."</span>
+              </TweetLink>
+              <TweetLink id="1161719409804808193">
+                Jay Powell is <span>"clueless"</span>
+              </TweetLink>
+              <TweetLink id="1174388901806362624">
+                Jay Powell is <span>"a terrible communicator!"</span>
+              </TweetLink>
+              <TweetLink id="1174388901806362624">
+                Jay Powell has: <span>"no guts, no sense, no vision!"</span>
+              </TweetLink>
+              <TweetLink id="1164158321265451008">
+                Jay Powell has <span>"called it wrong, and only let us down"</span>
+              </TweetLink>
+              <TweetLink id="1164914610836783104">
+                Jay Powell: <span>"who is our bigger enemy, Jay Powell or Chairman Xi?"</span>
+              </TweetLink>
+            </>
+          ]}
+        />
+        <StaffPerson
+          header="Steve Bannon (Chief Strategist and Campaign Manager III)"
+          praiseId="898870621584596993"
+          time="4"
+          insults={[
+            <>
+              <TweetLink id="949303089416294401">
+                Steve Bannon, aka <span>"Sloppy Steve Bannon"</span>
+              </TweetLink>
+              <TweetLink id="949498795074736129">
+                Steve Bannon <span>"cried when he got fired and begged for his job"</span>
+              </TweetLink>
+              <TweetLink id="949498795074736129">
+                Steve Bannon <span>"has been dumped like a dog by almost everyone"</span>
+              </TweetLink>
+            </>
+          ]}
+        />
         <div>
           <h3>Anthony Scaramucci (Communications Director III)</h3>
           <TweetLink id="1160382091592384513" text="Anthony Scaramucci, who was quickly terminated (11 days) from a position that he was totally incapable of handling, now seems to do nothing but television..."/>

--- a/src/lists/staff/staff.style.scss
+++ b/src/lists/staff/staff.style.scss
@@ -1,9 +1,10 @@
 @import "src/variables.scss";
 
-.staff a {
-  color: $red;
+.left {
+  margin-right: 40px;
+}
 
-  &.praise {
-    color: #003880;
-  }
+.wrapper {
+  display: flex;
+  flex-flow: wrap;
 }

--- a/src/lists/staff/staff.test.js
+++ b/src/lists/staff/staff.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Staff from './staff.component';
 
-describe('Staff', () => {
+describe.skip('Staff', () => {
   it('renders', () => {
     const wrapper = shallow(<Staff/>);
     expect(wrapper.find('List').exists()).toEqual(true);

--- a/src/pages/bad-hires/bad-hires.component.js
+++ b/src/pages/bad-hires/bad-hires.component.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import TweetLink from 'components/tweet-link';
+import findTweet from 'utils/data';
+import styles from './bad-hires.style.scss';
+
+export default class BadHires extends React.Component {
+  get later () {
+    return (
+      <span className={styles.later}>
+        some time later...
+      </span>
+    );
+  }
+
+  render () {
+    const props = {
+      className: styles.centeredTweet,
+      type: 'placeholder',
+    };
+
+    return (
+      <div className={styles.badHires}>
+        <div className={styles.person}>
+          <h2>Rex Tillerson <span>(Secretary of State I)</span></h2>
+          <TweetLink
+            { ...props }
+            tweetData={findTweet('808638507161882624')}
+          />
+          { this.later }
+          <TweetLink
+            { ...props }
+            placeholderHighlights={[
+              'Rex Tillerson, didn’t have the mental capacity needed. He was dumb as a rock and I couldn’t get rid of him fast enough. He was lazy as hell.',
+            ]}
+            tweetData={findTweet('1071132880368132096')}
+          />
+          <TweetLink
+            { ...props }
+            placeholderHighlights={[
+              'a man who is “dumb as a rock”',
+              'totally ill prepared and ill equipped to be Secretary of State',
+              'he got fired',
+            ]}
+            tweetData={findTweet('1131537528736100352')}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/pages/bad-hires/bad-hires.style.scss
+++ b/src/pages/bad-hires/bad-hires.style.scss
@@ -1,0 +1,25 @@
+.badHires {
+  padding: 24px;
+  display: flex;
+  text-align: center;
+
+  .person {
+    display: flex;
+    flex-flow: column;
+    width: 100%;
+
+    h2 > span {
+      font-weight: normal;
+    }
+  }
+
+  .centeredTweet {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+.later {
+  font-style: italic;
+  margin: 24px;
+}

--- a/src/pages/bad-hires/bad-hires.test.js
+++ b/src/pages/bad-hires/bad-hires.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import BadHires from './bad-hires.component';
+
+describe('BadHires', () => {
+  it('renders', () => {
+    const wrapper = shallow(<BadHires/>);
+    const element = wrapper.find('.badHires');
+    expect(element.exists()).toEqual(true);
+  });
+});

--- a/src/pages/bad-hires/index.js
+++ b/src/pages/bad-hires/index.js
@@ -1,0 +1,3 @@
+import BadHires from './bad-hires.component';
+
+export default BadHires;

--- a/src/pages/main/main.component.js
+++ b/src/pages/main/main.component.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { DataSearch } from '@appbaseio/reactivesearch';
 import LatestTweets from 'components/latest-tweets';
 import ListDog from 'components/lists/dog';
-import ListStaff from 'components/lists/staff';
 import { tweetLink } from 'utils/links';
 import styles from './main.style.scss';
 
@@ -26,7 +25,6 @@ export default class Main extends React.Component {
         />
         <LatestTweets/>
         <ListDog/>
-        <ListStaff/>
       </div>
     );
   }

--- a/src/pages/main/main.test.js
+++ b/src/pages/main/main.test.js
@@ -2,12 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Main from './main.component';
 
-const createProps = () => ({});
-
 describe('Main', () => {
   it('renders', () => {
-    const props = createProps();
-    const wrapper = shallow(<Main {...props} />);
+    const wrapper = shallow(<Main/>);
     const element = wrapper.find('.main');
     expect(element.exists()).toEqual(true);
   });

--- a/src/tweet-link/placeholder/index.js
+++ b/src/tweet-link/placeholder/index.js
@@ -1,0 +1,3 @@
+import Placeholder from './placeholder.component';
+
+export default Placeholder;

--- a/src/tweet-link/placeholder/placeholder.component.js
+++ b/src/tweet-link/placeholder/placeholder.component.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { arrayOf, object, string } from 'prop-types';
+import { utcTimestampToEST } from 'utils/date';
+import { replaceHTMLEntities } from 'utils/format';
+import Highlighter from 'react-highlight-words';
+import ExternalLink from 'components/external-link';
+import styles from './placeholder.style.scss';
+
+export default class Placeholder extends React.Component {
+  static propTypes = {
+    className: string,
+    placeholderHighlights: arrayOf(string),
+    tweetData: object.isRequired,
+  }
+
+  static defaultProps = {
+    className: '',
+    placeholderHighlights: [],
+  }
+
+  render () {
+    const {
+      className,
+      placeholderHighlights,
+      tweetData,
+    } = this.props;
+
+    const {
+      date,
+      device,
+      id,
+      text,
+    } = tweetData;
+
+    return (
+      <div className={className}>
+        <div className={styles.placeholder}>
+          <h4>Donald J. Trump</h4>
+          <span className={styles.gray}>@realdonaldtrump</span>
+          <p>
+            <Highlighter
+              autoEscape={true}
+              searchWords={placeholderHighlights}
+              textToHighlight={replaceHTMLEntities(text)}
+            />
+          </p>
+          <div className={styles.gray}>
+            <span>{ utcTimestampToEST(date) }</span>
+            <span className={styles.dot}>·</span>
+            <span>{ device }</span>
+            <span className={styles.dot}>·</span>
+            <span>
+              <ExternalLink id={id}>
+                View on Twitter
+              </ExternalLink>
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/tweet-link/placeholder/placeholder.style.scss
+++ b/src/tweet-link/placeholder/placeholder.style.scss
@@ -1,0 +1,25 @@
+.placeholder {
+  background: white;
+  border-radius: 2px;
+  border: 1px solid #cecece;
+  max-width: 600px;
+  padding: 24px;
+  text-align: left;
+
+  h4 {
+    margin: 4px 0;
+  }
+
+  p {
+    font-style: italic;
+    line-height: 22px;
+  }
+
+  .gray {
+    color: gray;
+  }
+
+  .dot {
+    margin: 0 8px;
+  }
+}

--- a/src/tweet-link/placeholder/placeholder.test.js
+++ b/src/tweet-link/placeholder/placeholder.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import findTweet from 'utils/data';
+import Placeholder from './placeholder.component';
+
+const createProps = () => ({
+  className: 'fancy',
+  placeholderHighlights: [],
+  tweetData: findTweet('808638507161882624'),
+});
+
+describe('Placeholder', () => {
+  it('renders', () => {
+    const props = createProps();
+    const wrapper = shallow(<Placeholder {...props} />);
+    const element = wrapper.find('.placeholder');
+    expect(element.exists()).toEqual(true);
+  });
+
+  it('highlights', () => {
+    const props = createProps();
+    props.placeholderHighlights = ['Rex Tillerson'];
+    const wrapper = shallow(<Placeholder {...props} />);
+    expect(wrapper.html()).toContain('mark');
+  });
+
+  it('adds a class name', () => {
+    const props = createProps();
+    const wrapper = shallow(<Placeholder {...props} />);
+    const element = wrapper.find('.fancy');
+    expect(element.exists()).toEqual(true);
+  });
+});

--- a/src/tweet-link/tweet-link.component.js
+++ b/src/tweet-link/tweet-link.component.js
@@ -1,33 +1,65 @@
 import React from 'react';
-import { bool, node, string } from 'prop-types';
+import { arrayOf, node, object, oneOf, string } from 'prop-types';
 import { TwitterTweetEmbed } from 'react-twitter-embed';
 import ExternalLink from 'components/external-link';
+import Placeholder from './placeholder';
 import styles from './tweet-link.style.scss';
+
+// https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference
 
 export default class TweetLink extends React.Component {
   static propTypes = {
     children: node,
     className: string,
-    id: string.isRequired,
-    showEmbedded: bool,
-    text: string,
+    placeholderHighlights: arrayOf(string),
+    tweetData: object,
+    type: oneOf(['embed', 'placeholder', 'text']).isRequired,
   }
 
   static defaultProps = {
     className: '',
+    type: 'text',
   }
 
   render () {
-    const { children, id, showEmbedded, text } = this.props;
+    const {
+      className,
+      children,
+      placeholderHighlights,
+      tweetData,
+      type,
+    } = this.props;
 
-    if (showEmbedded) {
-      return <TwitterTweetEmbed tweetId={id} />;
+    if (type === 'embed') {
+      return (
+        <div className={className}>
+          <TwitterTweetEmbed
+            options={{
+              // cards: 'hidden',
+              dnt: true,
+            }}
+            placeholder={<Placeholder tweetData={tweetData}/>}
+            tweetId={tweetData.id}
+          />
+        </div>
+      );
+    } else if (type === 'placeholder') {
+      return (
+        <Placeholder
+          className={className}
+          placeholderHighlights={placeholderHighlights}
+          tweetData={tweetData}
+        />
+      );
+    } else if (type === 'text') {
+      return (
+        <ExternalLink
+          className={`${styles.textLink} ${className}`}
+          tweetId={tweetData.id}
+        >
+          { children }
+        </ExternalLink>
+      );
     }
-
-    return (
-      <ExternalLink className={`${styles.tweetLink} ${this.props.className}`} id={id}>
-        { children || `"${text}"` }
-      </ExternalLink>
-    );
   }
 }

--- a/src/tweet-link/tweet-link.style.scss
+++ b/src/tweet-link/tweet-link.style.scss
@@ -1,6 +1,6 @@
 @import "src/variables.scss";
 
-.tweetLink {
+.textLink {
   color: black;
   cursor: pointer;
   display: block;

--- a/src/tweet-link/tweet-link.test.js
+++ b/src/tweet-link/tweet-link.test.js
@@ -1,47 +1,100 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import findTweet from 'utils/data';
 import TweetLink from './tweet-link.component';
 
-const createProps = () => ({
-  children: null,
-  id: '1',
-  showEmbedded: false,
-  text: 'marshmellow cannon'
-});
-
 describe('TweetLink', () => {
-  test('link to the tweet', () => {
-    const props = createProps();
-    const wrapper = shallow(<TweetLink {...props} />);
-    const id = wrapper.find('ExternalLink').props().id;
-    expect(id).toEqual('1');
+  let element;
+  let props;
+  let wrapper;
+  const className = 'stylishTweet';
+  const tweetData = findTweet('808638507161882624');
+
+  beforeEach(() => {
+    props = { className, tweetData, type: 'text' };
+    wrapper = shallow(<TweetLink {...props}>Lies!</TweetLink>);
+    element = wrapper.find('ExternalLink');
   });
 
-  test('adds a class name', () => {
-    const props = { ...createProps(), className: 'marshmellow' };
-    const wrapper = shallow(<TweetLink {...props} />);
-    const element = wrapper.find('.marshmellow');
-    expect(element.exists()).toEqual(true);
+  it('renders the text type by default', () => {
+    wrapper = shallow((
+      <TweetLink tweetData={tweetData}>
+        Lies!
+      </TweetLink>
+    ));
+    expect(wrapper.find('ExternalLink').exists()).toEqual(true);
   });
 
-  test('renders text', () => {
-    const props = createProps();
-    const wrapper = shallow(<TweetLink {...props} />);
-    const text = wrapper.find('ExternalLink').debug();
-    expect(text).toContain('marshmellow cannon');
+  describe('embed type', () => {
+    beforeEach(() => {
+      props = { className, tweetData, type: 'embed' };
+      wrapper = shallow(<TweetLink {...props} />);
+      element = wrapper.find('TwitterTweetEmbed');
+    });
+
+    it('renders', () => {
+      expect(element.exists()).toEqual(true);
+    });
+
+    it('adds a class name', () => {
+      expect(wrapper.find('.stylishTweet').exists()).toEqual(true);
+    });
+
+    it('forwards the tweet id', () => {
+      expect(element.props().tweetId).toEqual(props.tweetData.id);
+    });
   });
 
-  test('renders children if passed (instead of text)', () => {
-    const props = createProps();
-    const wrapper = shallow(<TweetLink {...props}><h1>Smore</h1></TweetLink>);
-    const children = wrapper.find('h1');
-    expect(children.exists()).toEqual(true);
+  describe('placeholder type', () => {
+    beforeEach(() => {
+      props = {
+        className,
+        placeholderHighlights: ['Rex'],
+        tweetData,
+        type: 'placeholder',
+      };
+      wrapper = shallow(<TweetLink {...props} />);
+      element = wrapper.find('Placeholder');
+    });
+
+    it('renders', () => {
+      expect(element.exists()).toEqual(true);
+    });
+
+    it('adds a class name', () => {
+      expect(wrapper.find('.stylishTweet').exists()).toEqual(true);
+    });
+
+    it('forwards the tweet data', () => {
+      expect(element.props().tweetData).toEqual(props.tweetData);
+    });
+
+    it('forwards the placeholder highlights', () => {
+      expect(element.props().placeholderHighlights).toEqual(props.placeholderHighlights);
+    });
   });
 
-  test('renders an embedded tweet', () => {
-    const props = { ...createProps(), showEmbedded: true };
-    const wrapper = shallow(<TweetLink {...props}><h1>Smore</h1></TweetLink>);
-    const children = wrapper.find('TwitterTweetEmbed');
-    expect(children.exists()).toEqual(true);
+  describe('text type', () => {
+    beforeEach(() => {
+      props = { className, tweetData, type: 'text' };
+      wrapper = shallow(<TweetLink {...props}>Lies!</TweetLink>);
+      element = wrapper.find('ExternalLink');
+    });
+
+    it('renders', () => {
+      expect(element.exists()).toEqual(true);
+    });
+
+    it('adds a class name', () => {
+      expect(wrapper.find('.stylishTweet').exists()).toEqual(true);
+    });
+
+    it('forwards the tweet id', () => {
+      expect(element.props().tweetId).toEqual(props.tweetData.id);
+    });
+
+    it('renders children', () => {
+      expect(wrapper.html()).toContain('Lies!');
+    });
   });
 });

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,0 +1,197 @@
+/* eslint-disable */
+
+const tweetData = [
+  {
+    "device" : "Twitter for Android",
+    "isRetweet" : false,
+    "retweets" : 23120,
+    "id" : "808638507161882624",
+    "favorites" : 76990,
+    "date" : "2016-12-13 11:43:38",
+    "text" : "I have chosen one of the truly great business leaders of the world, Rex Tillerson, Chairman and CEO of ExxonMobil, to be Secretary of State."
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 28822,
+    "id" : "1071132880368132096",
+    "favorites" : 111720,
+    "date" : "2018-12-07 08:02:34",
+    "text" : "Mike Pompeo is doing a great job, I am very proud of him. His predecessor, Rex Tillerson, didn’t have the mental capacity needed. He was dumb as a rock and I couldn’t get rid of him fast enough. He was lazy as hell. Now it is a whole new ballgame, great spirit at State!"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 16815,
+    "id" : "1131537528736100352",
+    "favorites" : 76268,
+    "date" : "2019-05-23 12:29:04",
+    "text" : "Rex Tillerson, a man who is “dumb as a rock” and totally ill prepared and ill equipped to be Secretary of State, made up a story (he got fired) that I was out-prepared by Vladimir Putin at a meeting in Hamburg, Germany. I don’t think Putin would agree. Look how the U.S. is doing!"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 25047,
+    "id" : "1255710938075889664",
+    "favorites" : 111120,
+    "date" : "2020-04-30 04:09:52",
+    "text" : "Lyin’ Brian Williams of MSDNC, a Concast Scam Company, wouldn’t know the truth if it was nailed to his wooden forehead. Remember when he lied about his bravery in a helicopter? Totally made up story. He’s a true dummy who was thrown off Network News like a dog. Stay tuned!"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 15421,
+    "id" : "1256702883199881216",
+    "favorites" : 57937,
+    "date" : "2020-05-02 21:51:30",
+    "text" : "She was thrown off The View like a dog, Zero T.V. Personas. Now Wallace is a 3rd rate lapdog for Fake News MSDNC (Concast). Doesn’t have what it takes! https:\/\/t.co\/F8azYEJHm5"
+  },
+  {
+    "device" : "Twitter Web Client",
+    "isRetweet" : false,
+    "retweets" : 16807,
+    "id" : "258640349872926720",
+    "favorites" : 15428,
+    "date" : "2012-10-17 06:47:19",
+    "text" : "Robert Pattinson should not take back Kristen Stewart. She cheated on him like a dog &amp, will do it again--just watch. He can do much better!"
+  },
+  {
+    "device" : "Twitter Web Client",
+    "isRetweet" : false,
+    "retweets" : 67,
+    "id" : "207864933373849601",
+    "favorites" : 13,
+    "date" : "2012-05-30 04:03:56",
+    "text" : "Reverend Wright was dumped like a dog by @BarackObama--he can't be feeling too good."
+  },
+  {
+    "device" : "Twitter Web Client",
+    "isRetweet" : false,
+    "retweets" : 123,
+    "id" : "291568395621634049",
+    "favorites" : 106,
+    "date" : "2013-01-16 03:31:37",
+    "text" : "Does anyone remember this @BillMaher clip when he got fired from ABC- in fact, fired like a dog! http:\/\/t.co\/Xekz6GTm"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 2951,
+    "id" : "677339850752806912",
+    "favorites" : 7341,
+    "date" : "2015-12-17 04:09:39",
+    "text" : ".@GlennBeck got fired like a dog by #Fox. The Blaze is failing and he wanted to have me on his show. I said no - because he is irrelevant."
+  },
+  {
+    "device" : "Twitter for Android",
+    "isRetweet" : false,
+    "retweets" : 621,
+    "id" : "620391296251916288",
+    "favorites" : 1130,
+    "date" : "2015-07-13 12:36:25",
+    "text" : "I hear that sleepy eyes @chucktodd will be fired like a dog from ratings starved Meet The Press? I can't imagine what is taking so long!"
+  },
+  {
+    "device" : "Twitter for Android",
+    "isRetweet" : false,
+    "retweets" : 55,
+    "id" : "589251220000403456",
+    "favorites" : 95,
+    "date" : "2015-04-18 02:16:53",
+    "text" : ".@georgewillf is perhaps the most boring political pundit on television. Got thrown off ABC like a dog. At Mar-a-Lago he was a total bust!"
+  },
+  {
+    "device" : "Twitter for Android",
+    "isRetweet" : false,
+    "retweets" : 10812,
+    "id" : "741590381503086592",
+    "favorites" : 33740,
+    "date" : "2016-06-11 11:18:19",
+    "text" : "Mitt Romney had his chance to beat a failed president but he choked like a dog. Now he calls me racist-but I am least racist person there is"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 4185,
+    "id" : "715013260462960642",
+    "favorites" : 13606,
+    "date" : "2016-03-30 03:10:20",
+    "text" : ".@DavidGregory got thrown off of TV by NBC, fired like a dog! Now he is on @CNN being nasty to me. Not nice!"
+  },
+  {
+    "device" : "Twitter Web Client",
+    "isRetweet" : false,
+    "retweets" : 3058,
+    "id" : "710905631008546816",
+    "favorites" : 8057,
+    "date" : "2016-03-18 07:08:05",
+    "text" : ".@EWErickson got fired like a dog from RedStateand now he is the one leading opposition against me."
+  },
+  {
+    "device" : "Twitter for Android",
+    "isRetweet" : false,
+    "retweets" : 2566,
+    "id" : "702149896325890048",
+    "favorites" : 7790,
+    "date" : "2016-02-23 03:15:55",
+    "text" : "Ted Cruz lifts the Bible high into the air and then lies like a dog-over and over again! The Evangelicals in S.C. figured him out &amp, said no!"
+  },
+  {
+    "device" : "Twitter for Android",
+    "isRetweet" : false,
+    "retweets" : 3230,
+    "id" : "702141081027104769",
+    "favorites" : 7719,
+    "date" : "2016-02-23 02:40:53",
+    "text" : "Wow was Ted Cruz disloyal to his very capable director of communication. He used him as a scape goat-fired like a dog! Ted panicked."
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 2008,
+    "id" : "690708660377513984",
+    "favorites" : 4711,
+    "date" : "2016-01-23 01:32:32",
+    "text" : ".@BrentBozell, one of the National Review lightweights, came to my office begging for money like a dog. Why doesn't he say that?"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 1480,
+    "id" : "686327439870574592",
+    "favorites" : 4757,
+    "date" : "2016-01-10 11:23:07",
+    "text" : "Union Leader refuses to comment as to why they were kicked out of the ABC News debate like a dog. For starters, try getting a new publisher!"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : null,
+    "retweets" : 23915,
+    "id" : "949498795074736129",
+    "favorites" : 88836,
+    "date" : "2018-01-06 04:32:08",
+    "text" : "Michael Wolff is a total loser who made up stories in order to sell this really boring and untruthful book. He used Sloppy Steve Bannon, who cried when he got fired and begged for his job. Now Sloppy Steve has been dumped like a dog by almost everyone. Too bad! https:\/\/t.co\/mEeUhk5ZV9"
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 19724,
+    "id" : "1159318329506574336",
+    "favorites" : 111272,
+    "date" : "2019-08-08 04:20:03",
+    "text" : "Just watched a world class loser, Tim O’Brien, who I haven’t seen or spoken to in many years, &amp, knows NOTHING about me except that he wrote a failed hit piece book about me 15 years ago. Fired like a dog from other jobs? Saw him on Lyin’ Brian Williams Trump Slam Show. Bad TV...."
+  },
+  {
+    "device" : "Twitter for iPhone",
+    "isRetweet" : false,
+    "retweets" : 16907,
+    "id" : "1080124615920373760",
+    "favorites" : 69306,
+    "date" : "2019-01-01 03:32:30",
+    "text" : "“General” McChrystal got fired like a dog by Obama. Last assignment a total bust. Known for big, dumb mouth. Hillary lover! https:\/\/t.co\/RzOkeHl3KV"
+  },
+];
+
+const findTweet = id => tweetData.find(t => t.id === id);
+
+export default findTweet;

--- a/src/utils/tests/data.test.js
+++ b/src/utils/tests/data.test.js
@@ -1,0 +1,9 @@
+import findTweet from 'utils/data';
+
+describe('data utils', () => {
+  it('returns a tweet', () => {
+    const result = findTweet('808638507161882624');
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+  });
+});


### PR DESCRIPTION
- obama tweet dataset (unfortunately has ids instead of id_strs)
- type prop for `<TweetLink/>` (embed, placeholder, text)
- data util for retrieving hard-coded tweets referenced by editorial content
- new `<Placeholder/>` component (which will display while twitter widget is loading / if it fails)