### PR TITLE
Correct update year to 2021

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,3 @@
 export const LINK_CSV = 'https://drive.google.com/file/d/1xRKHaP-QwACMydlDnyFPEaFdtskJuBa6/view?usp=sharing';
 export const LINK_JSON = 'https://drive.google.com/file/d/16wm-2NTKohhcA26w-kaWfhLIGwl_oX95/view?usp=sharing';
-export const LINK_UPDATED_AT = '01/08/2020';
+export const LINK_UPDATED_AT = '01/08/2021';


### PR DESCRIPTION
The spreadsheet was last updated in 2021 but was incorrectly listed as 2020 due to the previous update in November 2020.